### PR TITLE
Add type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Currently, the following filters have been implemented:
 * [terms filter](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html)
 * [nested filter](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-filter.html)
 * [exists filter](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html)
+* [type filter](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html)
 
 ### Type checking and attribute coercion
 

--- a/lib/daedal.rb
+++ b/lib/daedal.rb
@@ -20,6 +20,7 @@ require 'daedal/attributes/field'
 require 'daedal/attributes/query_value'
 require 'daedal/attributes/boost'
 require 'daedal/attributes/score_function_array'
+require 'daedal/attributes/type_value'
 
 # filters
 require 'daedal/filters/exists_filter'
@@ -32,6 +33,7 @@ require 'daedal/filters/and_filter'
 require 'daedal/filters/or_filter'
 require 'daedal/filters/bool_filter'
 require 'daedal/filters/nested_filter'
+require 'daedal/filters/type_filter'
 
 # queries
 require 'daedal/queries/match_all_query'

--- a/lib/daedal/attributes/type_value.rb
+++ b/lib/daedal/attributes/type_value.rb
@@ -1,0 +1,18 @@
+module Daedal
+  module Attributes
+    """Custom coercer for the value of a type - can be a string or a symbol. If
+    it's none of those, raises a coercion error."""
+    class TypeValue < Virtus::Attribute
+      ALLOWED_QUERY_VALUE_CLASSES = [String, Symbol]
+      def coerce(q)
+        if !required? and q.nil?
+          return q
+        elsif ALLOWED_QUERY_VALUE_CLASSES.include? q.class
+          return q
+        else
+          raise Virtus::CoercionError.new(q, self.class)
+        end
+      end
+    end
+  end
+end

--- a/lib/daedal/filters/type_filter.rb
+++ b/lib/daedal/filters/type_filter.rb
@@ -1,0 +1,14 @@
+module Daedal
+  module Filters
+    """Class for the type filter"""
+    class TypeFilter < Filter
+
+      # required attributes
+      attribute :type, Daedal::Attributes::TypeValue
+
+      def to_hash
+        {type: {:value => type}}
+      end
+    end
+  end
+end

--- a/spec/unit/daedal/filters/type_filter_spec.rb
+++ b/spec/unit/daedal/filters/type_filter_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Daedal::Filters::TypeFilter do
+
+  subject do
+    Daedal::Filters::TypeFilter
+  end
+
+  let(:type) do
+    :bar
+  end
+
+  let(:hash_filter) do
+    {type: {:value => type}}
+  end
+
+  context 'without a type specified' do
+    it 'will raise an error' do
+      expect {subject.new}.to raise_error(Virtus::CoercionError)
+    end
+  end
+
+  context 'with a type specified' do
+    let(:filter) do
+      subject.new(type: type)
+    end
+    it 'will populate the type attribute appropriately' do
+      expect(filter.type).to eq type
+    end
+    it 'will have the correct hash representation' do
+      expect(filter.to_hash).to eq hash_filter
+    end
+    it 'will have the correct json representation' do
+      expect(filter.to_json).to eq hash_filter.to_json
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the [type filter](http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-filter.html)