### PR TITLE
Add simple query string query

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Currently, the following queries have been implemented:
 * [nested query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html)
 * [prefix query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html)
 * [query string query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html)
+* [simple query string query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)
 * [range query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-range-query.html)
 * [term query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-term-query.html)
 * [terms query](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html)

--- a/lib/daedal.rb
+++ b/lib/daedal.rb
@@ -21,6 +21,7 @@ require 'daedal/attributes/query_value'
 require 'daedal/attributes/boost'
 require 'daedal/attributes/score_function_array'
 require 'daedal/attributes/type_value'
+require 'daedal/attributes/flag'
 
 # filters
 require 'daedal/filters/exists_filter'
@@ -51,5 +52,6 @@ require 'daedal/queries/term_query'
 require 'daedal/queries/terms_query'
 require 'daedal/queries/range_query'
 require 'daedal/queries/function_score_query'
+require 'daedal/queries/simple_query_string_query'
 
 # facets

--- a/lib/daedal/attributes/flag.rb
+++ b/lib/daedal/attributes/flag.rb
@@ -1,0 +1,33 @@
+module Daedal
+  module Attributes
+    """Custom coercer for the flag attribute"""
+    class Flag < Virtus::Attribute
+      ALLOWED_FLAGS = [
+        :all,
+        :none,
+        :and,
+        :or,
+        :not,
+        :prefix,
+        :phrase,
+        :precedence,
+        :escape,
+        :whitespace,
+        :fuzzy,
+        :near,
+        :slop
+      ]
+
+      def coerce(value)
+        unless value.nil?
+          value = value.to_sym
+          unless ALLOWED_FLAGS.include? value
+            raise Virtus::CoercionError.new(value, 'Daedal::Attributes::Flag')
+          end
+        end
+        value
+      end
+    end
+  end
+end
+

--- a/lib/daedal/queries/simple_query_string_query.rb
+++ b/lib/daedal/queries/simple_query_string_query.rb
@@ -1,0 +1,43 @@
+module Daedal
+  module Queries
+    """Class for the simple query string query"""
+    class SimpleQueryStringQuery < Query
+
+      # required attributes
+      attribute :query,                         String
+
+      # non required attributes
+      attribute :default_field,                 Daedal::Attributes::Field, required: false
+      attribute :fields,                        Array[Daedal::Attributes::Field], required: false
+      attribute :default_operator,              String, required: false
+      attribute :analyzer,                      Symbol, required: false
+      attribute :lowercase_expanded_terms,      Boolean, required: false
+      attribute :minimum_should_match,          Integer, required: false
+      attribute :lenient,                       Boolean, required: false
+      attribute :flags,                         Array[Daedal::Attributes::Flag], required: false
+
+      def to_hash
+        parameters = present_attributes
+
+        if parameters[:flags]
+          parameters[:flags] = parameters[:flags].map(&:to_s).join('|')
+        end
+
+        { simple_query_string: parameters }
+      end
+
+      private
+
+      def present_attributes
+        attributes.select do |parameter, value|
+          case parameter
+          when :fields, :flags
+            !value.empty?
+          else
+            !value.nil?
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/daedal/attributes/flag_spec.rb
+++ b/spec/unit/daedal/attributes/flag_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Daedal::Attributes::Flag do
+  class Whatever
+    include Virtus.model
+
+    attribute :flag, Daedal::Attributes::Flag
+  end
+
+  describe '#coerce' do
+    it 'coerces a coercible value' do
+      model = Whatever.new(flag: 'prefix')
+
+      expect(model.flag).to eq :prefix
+    end
+
+    it 'raises a coercion error if flag is not allowed' do
+      expect do
+        Whatever.new(flag: 'asdasdasdsa')
+      end.to raise_error Virtus::CoercionError
+    end
+  end
+end

--- a/spec/unit/daedal/queries/simple_query_string_spec.rb
+++ b/spec/unit/daedal/queries/simple_query_string_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+describe Daedal::Queries::SimpleQueryStringQuery do
+
+  subject do
+    Daedal::Queries::SimpleQueryStringQuery
+  end
+
+  let(:hash_query) do
+    {simple_query_string: {query: 'foo'}}
+  end
+
+  context 'without a query string' do
+    it 'will raise an error' do
+      expect{subject.new}.to raise_error(Virtus::CoercionError)
+    end
+  end
+
+  context 'with a query that is not a string given' do
+    let(:query) do
+      subject.new query: :foo
+    end
+    it 'will convert to a string' do
+      expect(query.query).to eq 'foo'
+    end
+  end
+
+  context 'with a query' do
+    let(:query) do
+      subject.new query: 'foo'
+    end
+    it 'will create a query string with the correct value' do
+      expect(query.query).to eq 'foo'
+    end
+    it 'will have the correct hash and json representation' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with a default_field' do
+    let(:query) do
+      subject.new query: 'foo', default_field: :bar
+    end
+    before do
+      hash_query[:simple_query_string][:default_field] = :bar
+    end
+    it 'will set the default_field' do
+      expect(query.default_field).to eq :bar
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with an array of fields' do
+    let(:query) do
+      subject.new query: 'foo', fields: [:bar]
+    end
+    before do
+      hash_query[:simple_query_string][:fields] = [:bar]
+    end
+    it 'will set the fields' do
+      expect(query.fields).to eq [:bar]
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with a default_operator' do
+    let(:query) do
+      subject.new query: 'foo', default_operator: 'OR'
+    end
+    before do
+      hash_query[:simple_query_string][:default_operator] = 'OR'
+    end
+    it 'will set the default_operator' do
+      expect(query.default_operator).to eq 'OR'
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with an analyzer' do
+    let(:query) do
+      subject.new query: 'foo', analyzer: :bar
+    end
+    before do
+      hash_query[:simple_query_string][:analyzer] = :bar
+    end
+    it 'will set the analyzer' do
+      expect(query.analyzer).to eq :bar
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with flags' do
+    let(:query) do
+      subject.new query: 'foo', flags: [:or, :and, :prefix]
+    end
+    before do
+      hash_query[:simple_query_string][:flags] = 'or|and|prefix'
+    end
+    it 'will set the flags' do
+      expect(query.flags).to eq [:or, :and, :prefix]
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with a lowercase_expanded_terms' do
+    let(:query) do
+      subject.new query: 'foo', lowercase_expanded_terms: true
+    end
+    before do
+      hash_query[:simple_query_string][:lowercase_expanded_terms] = true
+    end
+    it 'will set the lowercase_expanded_terms' do
+      expect(query.lowercase_expanded_terms).to eq true
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with a minimum_should_match' do
+    let(:query) do
+      subject.new query: 'foo', minimum_should_match: 2
+    end
+    before do
+      hash_query[:simple_query_string][:minimum_should_match] = 2
+    end
+    it 'will set the minimum_should_match' do
+      expect(query.minimum_should_match).to eq 2
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+
+  context 'with a lenient' do
+    let(:query) do
+      subject.new query: 'foo', lenient: true
+    end
+    before do
+      hash_query[:simple_query_string][:lenient] = true
+    end
+    it 'will set the lenient' do
+      expect(query.lenient).to eq true
+    end
+    it 'will have the correct hash and json representations' do
+      expect(query.to_hash).to eq hash_query
+      expect(query.to_json).to eq hash_query.to_json
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the [simple query string query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)