### PR TITLE
Removing minimum_should_match option from terms query

### DIFF
--- a/lib/daedal/queries/terms_query.rb
+++ b/lib/daedal/queries/terms_query.rb
@@ -7,11 +7,8 @@ module Daedal
       attribute :field, Daedal::Attributes::Field
       attribute :terms, Array[Daedal::Attributes::QueryValue]
 
-      # not required
-      attribute :minimum_should_match, Integer, default: 1, required: false
-
       def to_hash
-         {terms: {field => terms}, minimum_should_match: minimum_should_match}
+         {terms: {field => terms}}
       end
     end
   end

--- a/spec/unit/daedal/queries/terms_query_spec.rb
+++ b/spec/unit/daedal/queries/terms_query_spec.rb
@@ -15,7 +15,7 @@ describe Daedal::Queries::TermsQuery do
   end
 
   let(:hash_query) do
-    {terms: {field => terms} , minimum_should_match: 1}
+    {terms: {field => terms}}
   end
 
   context 'without a field or a list of terms specified' do
@@ -40,10 +40,6 @@ describe Daedal::Queries::TermsQuery do
       expect(terms_query.terms).to eq terms
     end
 
-    it 'will have minimum match option set to default 1' do
-      expect(terms_query.minimum_should_match).to eq 1
-    end
-
     it 'will have the correct hash representation' do
       expect(terms_query.to_hash).to eq hash_query
     end
@@ -52,29 +48,5 @@ describe Daedal::Queries::TermsQuery do
       expect(terms_query.to_json).to eq hash_query.to_json
     end
   end
-
-  context 'with minimum should match of 2 specified' do
-    let(:terms_query) do
-      subject.new(field: field, terms: terms, minimum_should_match: 2)
-    end
-
-    before do
-      hash_query[:minimum_should_match] = 2
-    end
-
-    it 'will set the phrase type to :phrase' do
-      expect(terms_query.minimum_should_match).to eq 2
-    end
-
-    it 'will have the correct hash representation' do
-      expect(terms_query.to_hash).to eq hash_query
-    end
-
-    it 'will have the correct json representation' do
-      expect(terms_query.to_json).to eq hash_query.to_json
-    end
-
-  end
-
 
 end


### PR DESCRIPTION
Current versions of ElasticSearch don't support the `minimum_should_match` option for the `terms` query any longer. Including the attribute in a `terms` clause results in errors like "[terms] malformed query, expected [END_OBJECT] but found [FIELD_NAME]".